### PR TITLE
trim feed input to remove illegal space or linebreaks in XML documents

### DIFF
--- a/src/Feed.php
+++ b/src/Feed.php
@@ -162,11 +162,11 @@ class Feed
 			if (!ini_get('open_basedir')) {
 				curl_setopt($curl, CURLOPT_FOLLOWLOCATION, TRUE); // sometime is useful :)
 			}
-			$result = curl_exec($curl);
+			$result = trim(curl_exec($curl));
 			$ok = curl_errno($curl) === 0 && curl_getinfo($curl, CURLINFO_HTTP_CODE) === 200;
 
 		} elseif ($user === NULL && $pass === NULL) {
-			$result = file_get_contents($url);
+			$result = trim(file_get_contents($url));
 			$ok = is_string($result);
 
 		} else {


### PR DESCRIPTION
I encountered some RSS feeds that had linebreaks or spaces in front of the XML declaration, which causes SimpleXMLElement to error out with "String could not be parsed as XML".  When Chrome encounters a similar problem with spaces in front of the XML declaration they  output this error:

> This page contains the following errors:
> 
> error on line 2 at column 6: XML declaration allowed only at the start of the document

So to solve this I suggest trimming the resulting rss source.
