### PR TITLE
Tell cURL to handle different encodings

### DIFF
--- a/src/Feed.php
+++ b/src/Feed.php
@@ -158,6 +158,7 @@ class Feed
 			}
 			curl_setopt($curl, CURLOPT_HEADER, FALSE);
 			curl_setopt($curl, CURLOPT_TIMEOUT, 20);
+			curl_setopt($curl, CURLOPT_ENCODING , "");
 			curl_setopt($curl, CURLOPT_RETURNTRANSFER, TRUE); // no echo, just return result
 			if (!ini_get('open_basedir')) {
 				curl_setopt($curl, CURLOPT_FOLLOWLOCATION, TRUE); // sometime is useful :)


### PR DESCRIPTION
Set the cURL option CURLOPT_ENCODING to "" to tell it to automatically
detect different encodings and decode the contents if possible (automatically handles gzipped content now)