### PR TITLE
Update Feed.php

### DIFF
--- a/src/Feed.php
+++ b/src/Feed.php
@@ -214,6 +214,7 @@ class Feed
 			curl_setopt($curl, CURLOPT_TIMEOUT, 20);
 			curl_setopt($curl, CURLOPT_ENCODING, '');
 			curl_setopt($curl, CURLOPT_RETURNTRANSFER, true); // no echo, just return result
+			curl_setopt($curl, CURLOPT_USERAGENT, '');
 			if (!ini_get('open_basedir')) {
 				curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true); // sometime is useful :)
 			}


### PR DESCRIPTION
Shopify doesn't accept a CURL without `CURLOPT_USERAGENT` option, it returns `403 Forbidden` instead.