### PR TITLE
Unify `link` property for Atom as in RSS

### DIFF
--- a/src/Feed.php
+++ b/src/Feed.php
@@ -104,6 +104,9 @@ class Feed
 
 		// generate 'timestamp' tag
 		foreach ($xml->entry as $entry) {
+			$link = (string)$entry->link['href'];
+			unset($entry->link);
+			$entry->link = $link;
 			$entry->timestamp = strtotime($entry->updated);
 		}
 		$feed = new self;


### PR DESCRIPTION
In rss we have tag `<link>https://example.com/articles/some-amazing-article</link>`,  
but in Atom we have `<link href="https://example.com/articles/some-amazing-article"/>`.  
So, lets extract it from `href` attr & put into `link` property.