### PR TITLE
Added support for JSON Feeds

### DIFF
--- a/example-json.php
+++ b/example-json.php
@@ -1,0 +1,27 @@
+<?php
+header('Content-Type: text/html; charset=utf-8');
+
+if (!ini_get('date.timezone')) {
+	date_default_timezone_set('Europe/Prague');
+}
+
+require_once 'src/Feed.php';
+
+$json = Feed::loadJsonfeed('https://www.jsonfeed.org/feed.json');
+
+?>
+
+<h1><?php echo htmlspecialchars($json->title) ?></h1>
+
+<p><i><?php if(isset($json->description)){ echo htmlspecialchars($json->description); } ?></i></p>
+
+<?php foreach ($json->items as $item): ?>
+	<h2><a href="<?php echo htmlspecialchars($item->url) ?>"><?php echo htmlspecialchars($item->title) ?></a>
+	<small><?php echo date('j.n.Y H:i', (int) $item->timestamp) ?></small></h2>
+
+	<?php if (isset($item->content_html)): ?>
+		<div><?php echo $item->content_html ?></div>
+	<?php else: ?>
+		<p><?php echo htmlspecialchars($item->summary) ?></p>
+	<?php endif ?>
+<?php endforeach ?>

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,12 @@ Download Atom feed from URL:
 $atom = Feed::loadAtom($url);
 ```
 
+Download JSON feed from URL:
+
+```php
+$json = Feed::loadJsonfeed($url);
+```
+
 You can also enable caching:
 
 ```php


### PR DESCRIPTION
Hi there!
I recently came across this great RSS/Atom Feed parsing library! A project of mine requires to not only support RSS and Atom feeds, but also the much  newer JSON Feed Standard (https://jsonfeed.org/version/1.1) so I thought why not add support for it to this great library?
Anyways, I added support for both JSON Feed 1.0 and JSON Feed 1.1 which can be used with
```php
$json = Feed::loadJsonfeed($url);
```

Hope this helps someone!

I understand that this is a RSS/Atom parser only right now so it's totally fine if you don't want to merge this PR - I'll just create my own fork then!

_Have a great day!_