### PR TITLE
adjustNamespaces: Prevent infinite children loop

### DIFF
--- a/src/Feed.php
+++ b/src/Feed.php
@@ -252,8 +252,12 @@ class Feed
 	{
 		foreach ($el->getNamespaces(true) as $prefix => $ns) {
 			$children = $el->children($ns);
+			$childrenCount = count($children);
 			foreach ($children as $tag => $content) {
 				$el->{$prefix . ':' . $tag} = $content;
+				if (--$childrenCount === 0) {
+					break;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Hi David,
I came across rss ([bad.rss.txt](https://github.com/dg/rss-php/files/9019437/bad.rss.txt)) that cause this piece of code to infinitely loop.

I am not rss nor xml expert so I do not know root cause but this patch fix it for me but I do not know if it is good solution?
