### PR TITLE
add CURLOPT_COOKIE and CURLOPT_PROXY

### DIFF
--- a/src/Feed.php
+++ b/src/Feed.php
@@ -218,6 +218,7 @@ class Feed
 			curl_setopt($curl, CURLOPT_TIMEOUT, 20);
 			curl_setopt($curl, CURLOPT_ENCODING, '');
 			curl_setopt($curl, CURLOPT_RETURNTRANSFER, true); // no echo, just return result
+			curl_setopt($curl, CURLOPT_USERAGENT, '');
 			if (!ini_get('open_basedir')) {
 				curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true); // sometime is useful :)
 			}

--- a/src/Feed.php
+++ b/src/Feed.php
@@ -20,6 +20,12 @@ class Feed
 
 	/** @var SimpleXMLElement */
 	protected $xml;
+	
+	/** @var string */
+	public static $cookie;
+	
+	/** @var string */
+	public static $proxyHostPort;
 
 
 	/**
@@ -212,6 +218,12 @@ class Feed
 			curl_setopt($curl, CURLOPT_URL, $url);
 			if ($user !== null || $pass !== null) {
 				curl_setopt($curl, CURLOPT_USERPWD, "$user:$pass");
+			}
+			if (self::$cookie) {
+			    curl_setopt($curl, CURLOPT_COOKIE, self::$cookie);
+			}
+			if (self::$proxyHostPort) {
+			    curl_setopt($curl, CURLOPT_PROXY, self::$proxyHostPort);
 			}
 			curl_setopt($curl, CURLOPT_USERAGENT, self::$userAgent); // some feeds require a user agent
 			curl_setopt($curl, CURLOPT_HEADER, false);


### PR DESCRIPTION
Hi David,

We use your library, very useful by the way thx. Our servers are behind a proxy. Would you mind adding this option to the CURL call ? Sometimes we call a protected rss feed wich needs a cookie too.

Best regards
Jérôme