### PR TITLE
Handle items at root, not under channel

### DIFF
--- a/src/Feed.php
+++ b/src/Feed.php
@@ -218,6 +218,7 @@ class Feed
 			curl_setopt($curl, CURLOPT_TIMEOUT, 20);
 			curl_setopt($curl, CURLOPT_ENCODING, '');
 			curl_setopt($curl, CURLOPT_RETURNTRANSFER, true); // no echo, just return result
+			curl_setopt($curl, CURLOPT_USERAGENT, '');
 			if (!ini_get('open_basedir')) {
 				curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true); // sometime is useful :)
 			}


### PR DESCRIPTION
Feeds like Slashdot have items outside the &lt;channel&gt; tags.  This commit brings them inside the channel tags.  This handles "rdf syntax", though sub-optimally; there are rdf tag links inside the channel tags that are ignored.